### PR TITLE
Update terminal integration example

### DIFF
--- a/first_run.txt
+++ b/first_run.txt
@@ -20,7 +20,7 @@ you can add this to the settings:
 
   {
     "terminal.integrated.profiles.linux": {
-      "flatpak": {
+      "host-bash": {
         "path": "/usr/bin/env",
         "args":  ["--", "flatpak-spawn", "--host", "bash"]
       }

--- a/first_run.txt
+++ b/first_run.txt
@@ -19,8 +19,13 @@ To make the Integrated Terminal automatically use the host system's shell,
 you can add this to the settings:
 
   {
-    "terminal.integrated.shell.linux": "/usr/bin/env",
-    "terminal.integrated.shellArgs.linux": ["--", "flatpak-spawn", "--host", "bash"]
+    "terminal.integrated.profiles.linux": {
+      "flatpak": {
+        "path": "/usr/bin/env",
+        "args":  ["--", "flatpak-spawn", "--host", "bash"]
+      }
+    },
+    "terminal.integrated.defaultProfile.linux": "flatpak"
   }
 
 This flatpak provides a standard development environment (gcc, python, etc).

--- a/first_run.txt
+++ b/first_run.txt
@@ -25,7 +25,7 @@ you can add this to the settings:
         "args":  ["--host", "bash"]
       }
     },
-    "terminal.integrated.defaultProfile.linux": "flatpak"
+    "terminal.integrated.defaultProfile.linux": "host-bash"
   }
 
 This flatpak provides a standard development environment (gcc, python, etc).

--- a/first_run.txt
+++ b/first_run.txt
@@ -21,8 +21,8 @@ you can add this to the settings:
   {
     "terminal.integrated.profiles.linux": {
       "host-bash": {
-        "path": "/usr/bin/env",
-        "args":  ["--", "flatpak-spawn", "--host", "bash"]
+        "path": "/usr/bin/flatpak-span",
+        "args":  ["--host", "bash"]
       }
     },
     "terminal.integrated.defaultProfile.linux": "flatpak"


### PR DESCRIPTION
`terminal.integrated.shell*` is currently deprecated (oss v1.58.2)
use alternative options of `terminal.integrated.profiles.*` .
see: https://code.visualstudio.com/docs/editor/integrated-terminal#_configuring-profiles